### PR TITLE
ブランド紐づけ解除: 汎用AI開発講座LPに変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>AI開発講座 | ホリエモンAI学校</title>
+<title>AI開発講座 | 実践型AIアプリ開発スクール</title>
 <meta name="description" content="日本語で話すだけで、アプリが作れる時代。AIを味方につけて、あなたのアイデアを形にする実践型AI開発講座。リスキリング補助金対応で実質9万円〜。">
-<meta property="og:title" content="AI開発講座 | ホリエモンAI学校">
+<meta property="og:title" content="AI開発講座 | 実践型AIアプリ開発スクール">
 <meta property="og:description" content="日本語で指示するだけでアプリ開発。最短5日間の実践型講座。リスキリング補助金75%対応。">
 <meta property="og:type" content="website">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -855,8 +855,8 @@ button { cursor: pointer; border: none; font-family: inherit; }
 <nav class="nav" id="nav">
   <div class="nav-inner">
     <a href="#" class="nav-logo">
-      <span class="logo-mark">H</span>
-      ホリエモンAI学校
+      <span class="logo-mark">A</span>
+      AI開発講座
     </a>
     <div class="nav-links">
       <a href="#courses">講座一覧</a>
@@ -893,7 +893,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
     </h1>
     <p class="hero-sub">
       AIを味方につけて、あなたのアイデアを形にする。<br>
-      ホリエモンAI学校の実践型AI開発講座で、<br>
+      実践型AI開発講座で、<br>
       プログラミング未経験からアプリ開発者へ。
     </p>
     <div class="hero-actions">
@@ -1206,11 +1206,11 @@ AI: 承知しました。
         あなたの「作りたい」を、一緒に形にしましょう。
       </p>
       <div class="final-cta-actions">
-        <a href="https://horiemon.ai/" class="btn-primary" target="_blank" rel="noopener">
+        <a href="#contact" class="btn-primary">
           無料相談を予約する
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </a>
-        <a href="https://horiemon.ai/" class="btn-secondary" target="_blank" rel="noopener">
+        <a href="#contact" class="btn-secondary">
           資料請求する
         </a>
       </div>
@@ -1224,8 +1224,8 @@ AI: 承知しました。
     <div class="footer-inner">
       <div class="footer-brand">
         <div class="nav-logo">
-          <span class="logo-mark">H</span>
-          ホリエモンAI学校
+          <span class="logo-mark">A</span>
+          AI開発講座
         </div>
         <p>AIを味方につけて、あなたのアイデアを形にする。日本語で話すだけでアプリが作れる、新しい学びの形。</p>
       </div>
@@ -1245,12 +1245,12 @@ AI: 承知しました。
           <h4>サポート</h4>
           <a href="#faq">FAQ</a>
           <a href="#contact">お問い合わせ</a>
-          <a href="https://horiemon.ai/" target="_blank" rel="noopener">ホリエモンAI学校</a>
+          <a href="#contact">運営について</a>
         </div>
       </div>
     </div>
     <div class="footer-bottom">
-      <span>&copy; 2026 ホリエモンAI学校. All rights reserved.</span>
+      <span>&copy; 2026 AI開発講座. All rights reserved.</span>
       <span>AI開発講座</span>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- ホリエモンAI学校の参照をすべて除去
- タイトル・OGP・ナビ・フッター・copyrightを汎用的な「AI開発講座」に変更
- 外部リンク（horiemon.ai）をページ内リンクに置換

## Test plan
- [ ] ページ内に「ホリエモン」「horiemon」の文字列がないことを確認
- [ ] 全リンクが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)