### PR TITLE
ファビコン追加: グラデーションAマークSVG

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ff273c"/>
+      <stop offset="100%" stop-color="#0088ff"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#12121e"/>
+      <stop offset="100%" stop-color="#0a0a14"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="7" fill="url(#bg)"/>
+  <rect x=".5" y=".5" width="31" height="31" rx="6.5" fill="none" stroke="url(#g)" stroke-opacity=".25"/>
+  <path d="M16 4.5L6.5 27h4.8l1.6-4h6.2l1.6 4h4.8L16 4.5zm0 6.8L18.8 19h-5.6L16 11.3z" fill="url(#g)"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 <meta property="og:title" content="AI開発講座 | 実践型AIアプリ開発スクール">
 <meta property="og:description" content="日本語で指示するだけでアプリ開発。最短5日間の実践型講座。リスキリング補助金75%対応。">
 <meta property="og:type" content="website">
+<link rel="icon" type="image/svg+xml" href="favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Zen+Kaku+Gothic+New:wght@400;500;700;900&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- サイトのカラースキーム（赤→青グラデーション）に合わせたSVGファビコンを追加
- ダーク背景（#12121e→#0a0a14）＋グラデーション枠線の「A」マーク
- index.htmlの`<head>`に`<link rel="icon">`を追加

## Test plan
- [ ] ブラウザタブにファビコンが表示される
- [ ] ダークテーマのブラウザでも視認性がある

🤖 Generated with [Claude Code](https://claude.com/claude-code)