### PR TITLE
長期伴走コースの月額料金を12万円に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -1038,7 +1038,7 @@ AI: 承知しました。
         <h3 class="course-name">アプリ開発<br>長期伴走コース</h3>
         <p class="course-desc">本気コース修了者向け。自分で開発を進めながら、プロのメンテナンス支援と最新技術を継続提供。</p>
         <div class="course-price">
-          <div><span class="actual"><span class="yen">&#165;</span>80,000</span> <span class="period">/ 月額</span></div>
+          <div><span class="actual"><span class="yen">&#165;</span>120,000</span> <span class="period">/ 月額</span></div>
         </div>
         <div class="subsidy-tag" style="background:rgba(0,136,255,0.08);border-color:rgba(0,136,255,0.2);color:var(--c-blue);">&#128218; 本気コース修了者限定</div>
         <ul class="course-features">
@@ -1139,7 +1139,7 @@ AI: 承知しました。
           <span class="arrow">&#9660;</span>
         </button>
         <div class="faq-answer">
-          <p>本気コース修了後、ご自身でアプリ開発を進めながら、プロによるメンテナンス支援・仕上げのサポート・最新AI技術の提供を月額8万円で継続的に受けられるコースです。開発の半分はご自身で、仕上げをプロが巻き取る形で効率的にアプリを完成させます。</p>
+          <p>本気コース修了後、ご自身でアプリ開発を進めながら、プロによるメンテナンス支援・仕上げのサポート・最新AI技術の提供を月額12万円で継続的に受けられるコースです。開発の半分はご自身で、仕上げをプロが巻き取る形で効率的にアプリを完成させます。</p>
         </div>
       </div>
       <div class="faq-item reveal">


### PR DESCRIPTION
## Summary
- 長期伴走コースの月額料金を¥80,000→¥120,000に変更
- コースカード表示とFAQ回答の2箇所を更新

## Test plan
- [ ] コースカードの価格表示が¥120,000になっていること
- [ ] FAQ「長期伴走コースはどのようなサポートですか？」の回答が月額12万円になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)