### PR TITLE
長期伴走コースにデジタル化・AI導入補助金2026の情報を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -1038,9 +1038,10 @@ AI: 承知しました。
         <h3 class="course-name">アプリ開発<br>長期伴走コース</h3>
         <p class="course-desc">本気コース修了者向け。自分で開発を進めながら、プロのメンテナンス支援と最新技術を継続提供。</p>
         <div class="course-price">
-          <div><span class="actual"><span class="yen">&#165;</span>120,000</span> <span class="period">/ 月額</span></div>
+          <span class="original">&#165;120,000</span>
+          <div><span class="actual"><span class="yen">&#165;</span>60,000&#12316;</span> <span class="period">/ 月額</span></div>
         </div>
-        <div class="subsidy-tag" style="background:rgba(0,136,255,0.08);border-color:rgba(0,136,255,0.2);color:var(--c-blue);">&#128218; 本気コース修了者限定</div>
+        <div class="subsidy-tag">&#127919; デジタル化・AI導入補助金2026 最大1/2補助</div>
         <ul class="course-features">
           <li><span class="check">&#10003;</span>月額制の継続サポート</li>
           <li><span class="check">&#10003;</span>自走開発 + プロの仕上げ</li>
@@ -1048,6 +1049,7 @@ AI: 承知しました。
           <li><span class="check">&#10003;</span>最新AI技術の継続提供</li>
           <li><span class="check">&#10003;</span>必要に応じてリアル対応</li>
         </ul>
+        <p style="font-size:0.7rem;color:var(--c-muted);margin:0 0 16px;line-height:1.6;">開発例：顧客管理・営業支援、請求・売上管理、経営分析ダッシュボード、社内業務効率化など</p>
         <button class="course-cta secondary" onclick="scrollToContact()">詳細を相談する</button>
       </div>
     </div>
@@ -1139,7 +1141,16 @@ AI: 承知しました。
           <span class="arrow">&#9660;</span>
         </button>
         <div class="faq-answer">
-          <p>本気コース修了後、ご自身でアプリ開発を進めながら、プロによるメンテナンス支援・仕上げのサポート・最新AI技術の提供を月額12万円で継続的に受けられるコースです。開発の半分はご自身で、仕上げをプロが巻き取る形で効率的にアプリを完成させます。</p>
+          <p>本気コース修了後、ご自身でアプリ開発を進めながら、プロによるメンテナンス支援・仕上げのサポート・最新AI技術の提供を月額12万円（デジタル化・AI導入補助金適用で実質6万円〜）で継続的に受けられるコースです。顧客管理や売上管理、経営分析、社内業務効率化など、幅広い業務アプリの開発・運用をサポートします。</p>
+        </div>
+      </div>
+      <div class="faq-item reveal">
+        <button class="faq-question" onclick="toggleFaq(this)">
+          デジタル化・AI導入補助金とは何ですか？
+          <span class="arrow">&#9660;</span>
+        </button>
+        <div class="faq-answer">
+          <p>2026年度から始まった国の補助金制度で、中小企業・小規模事業者のIT導入を支援します。対象となるITツールの導入費用が最大1/2補助されます。長期伴走コースは本補助金の対象となる予定です。適用条件や申請方法の詳細は無料相談にてご案内します。</p>
         </div>
       </div>
       <div class="faq-item reveal">


### PR DESCRIPTION
## Summary
- 長期伴走コースのカードに補助後価格（実質¥60,000〜/月）と「デジタル化・AI導入補助金2026 最大1/2補助」タグを追加
- 開発例（顧客管理・営業支援、請求・売上管理、経営分析ダッシュボード、社内業務効率化）を添え書きとして表示
- FAQに「デジタル化・AI導入補助金とは？」を新規追加、長期伴走コースの説明も更新

## Test plan
- [ ] 長期伴走コースカードの価格表示（取り消し線＋補助後価格）が正しく表示されること
- [ ] 補助金タグが緑色で正しく表示されること
- [ ] 開発例の添え書きが小さめ文字で表示されること
- [ ] FAQの新規項目「デジタル化・AI導入補助金とは？」が展開できること
- [ ] モバイル表示でレイアウトが崩れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)