### PR TITLE
feat: サイトコンテンツ全面刷新 - 6サービス体系に再構成

### DIFF
--- a/index.html
+++ b/index.html
@@ -846,7 +846,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   max-height: 0; overflow: hidden;
   transition: max-height 0.4s ease, padding 0.4s ease;
 }
-.faq-item.active .faq-answer { max-height: 300px; }
+.faq-item.active .faq-answer { max-height: var(--faq-height, 300px); }
 .faq-answer p {
   padding-bottom: 24px;
   font-size: 0.95rem;
@@ -1464,8 +1464,15 @@ function closeMobileMenu() { mobileMenu.classList.remove('open'); }
 function toggleFaq(btn) {
   const item = btn.parentElement;
   const wasActive = item.classList.contains('active');
-  document.querySelectorAll('.faq-item.active').forEach(el => el.classList.remove('active'));
-  if (!wasActive) item.classList.add('active');
+  document.querySelectorAll('.faq-item.active').forEach(el => {
+    el.classList.remove('active');
+    el.querySelector('.faq-answer').style.removeProperty('--faq-height');
+  });
+  if (!wasActive) {
+    const answer = item.querySelector('.faq-answer');
+    answer.style.setProperty('--faq-height', answer.scrollHeight + 'px');
+    item.classList.add('active');
+  }
 }
 
 /* Scroll to contact */


### PR DESCRIPTION
## Summary
- 研修3コース（Google AI / Claude Code / 業務省人化）+ 伴走コース + 受託開発 + 保守の6サービス体系にLP全体を刷新
- ヒーロー・課題提示・解決策・コース・開発保守・FAQ・ナビ・フッター全セクションを新体系に合わせて更新
- 補助金表示を「自己負担 ¥90,000」中心の新デザインに変更
- 伴走コースをワイドカードで差別化、開発・保守セクションに価格表示を新設

## Test plan
- [ ] デスクトップ表示（1200px+）で全セクションのレイアウト確認
- [ ] タブレット表示（768px-1024px）でコースカードの2列表示確認
- [ ] モバイル表示（375px）で1列レスポンシブ確認
- [ ] ナビリンク（研修コース・開発保守・FAQ・無料相談）の遷移確認
- [ ] 全CTAボタン（無料相談予約・詳細相談）のリンク動作確認
- [ ] FAQアコーディオンの開閉動作確認
- [ ] モバイルハンバーガーメニューの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)