### PR TITLE
fix: 業務省人化コースにCoworkスキル・プラグイン体系を反映

### DIFF
--- a/courses/business-automation.html
+++ b/courses/business-automation.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>非エンジニアのための業務省人化 | AI開発講座</title>
-<meta name="description" content="Claude Desktop + MCPプラグインで、日々の業務を自動化。プログラミング不要。2時間×5回の集中研修。リスキリング補助金対応で自己負担9万円。">
+<meta name="description" content="Claude Coworkのプラグインとスキルで、日々の業務を自動化。プログラミング不要。2時間×5回の集中研修。リスキリング補助金対応で自己負担9万円。">
 <meta property="og:title" content="非エンジニアのための業務省人化 | AI開発講座">
-<meta property="og:description" content="Claude Desktopで業務自動化。プラグインで業務ツールと連携、定型業務を効率化。リスキリング補助金対応。">
+<meta property="og:description" content="Claude Coworkで業務自動化。プラグインとスキルで業務ツールと連携、定型業務を効率化。リスキリング補助金対応。">
 <meta property="og:type" content="website">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -723,7 +723,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
       非エンジニアのための<br>業務省人化
     </h1>
     <p class="course-hero-sub">
-      Claude Desktop + MCPプラグインで、日々の業務を自動化。<br>
+      Claude Coworkのプラグインとスキルで、日々の業務を自動化。<br>
       プログラミング経験は一切不要。AIに日本語で指示するだけで、<br>
       メール整理・資料作成・データ分析を効率化できます。
     </p>
@@ -823,7 +823,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">プラグイン（MCP）で業務ツールとつなげる</span>
+              <span class="curriculum-theme">プラグインとスキルで業務ツールとつなげる</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -831,14 +831,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> MCPプラグインとは — AIの拡張機能</div>
-                <div class="curriculum-topic"><span class="check">✓</span> ワンクリックインストールの方法</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Google Drive・Gmail・Calendarとの連携設定</div>
-                <div class="curriculum-topic"><span class="check">✓</span> ファイル読み取り・メール下書き作成の実践</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Coworkプラグインとは — スキル・コネクタ・コマンドのバンドル</div>
+                <div class="curriculum-topic"><span class="check">✓</span> プラグインマーケットプレイスからのインストール</div>
+                <div class="curriculum-topic"><span class="check">✓</span> コネクタでGoogle Drive・Gmail・Slackと連携</div>
+                <div class="curriculum-topic"><span class="check">✓</span> スラッシュコマンド（/）でスキルを呼び出す実践</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>Google Driveの資料をAIに要約させ、報告メールの下書きを作成する</p>
+                <p>プラグインを導入し、Google Driveの資料をAIに要約させ、報告メールの下書きを作成する</p>
               </div>
             </div>
           </div>
@@ -851,7 +851,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">Projectsで「自分専用AI」を作る</span>
+              <span class="curriculum-theme">スキルで「自分専用AI」を作る</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -859,14 +859,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> Projects機能の概要（カスタム指示 + 知識ベース）</div>
-                <div class="curriculum-topic"><span class="check">✓</span> 業務マニュアルやFAQをProjectに登録</div>
-                <div class="curriculum-topic"><span class="check">✓</span> 業種別テンプレートの活用</div>
-                <div class="curriculum-topic"><span class="check">✓</span> チームメンバーとの共有設定</div>
+                <div class="curriculum-topic"><span class="check">✓</span> スキルとは — 業務知識をAIに教え込む仕組み</div>
+                <div class="curriculum-topic"><span class="check">✓</span> カスタムスキルの作り方（Skill.md + ZIP）</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Skills Directoryから業種別スキルを導入</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Projectsと組み合わせて知識ベースを構築</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>自社のFAQ回答ボットをProjectsで作成し、実際に質問に回答させる</p>
+                <p>自社FAQ対応のカスタムスキルを作成し、スラッシュコマンドで呼び出せるようにする</p>
               </div>
             </div>
           </div>
@@ -879,7 +879,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">Artifactsで業務を自動化する</span>
+              <span class="curriculum-theme">スキル × Artifactsで業務を自動化する</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -887,14 +887,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> Artifacts深掘り（.docx / .xlsx / .pptx生成）</div>
-                <div class="curriculum-topic"><span class="check">✓</span> 定型業務のテンプレート化</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Artifactsで.docx / .xlsx / .pptxを自動生成</div>
+                <div class="curriculum-topic"><span class="check">✓</span> スキルで定型業務をテンプレート化</div>
                 <div class="curriculum-topic"><span class="check">✓</span> 報告書・提案書の自動ドラフト作成</div>
-                <div class="curriculum-topic"><span class="check">✓</span> データ分析レポートの自動生成</div>
+                <div class="curriculum-topic"><span class="check">✓</span> カスタムプラグインの作成（Plugin Create）</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>月次報告書のドラフトをAIに自動生成させ、テンプレートとして保存する</p>
+                <p>月次報告書スキルを作成し、スラッシュコマンド一発でドラフトを自動生成する</p>
               </div>
             </div>
           </div>
@@ -915,7 +915,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> 複数プラグインを組み合わせたワークフロー</div>
+                <div class="curriculum-topic"><span class="check">✓</span> 複数のスキル・プラグインを組み合わせたワークフロー</div>
                 <div class="curriculum-topic"><span class="check">✓</span> 部署別の活用事例（営業・経理・人事・総務）</div>
                 <div class="curriculum-topic"><span class="check">✓</span> セキュリティとプライバシーの注意点</div>
                 <div class="curriculum-topic"><span class="check">✓</span> 社内展開のステップ</div>
@@ -946,12 +946,12 @@ button { cursor: pointer; border: none; font-family: inherit; }
       <div class="skill-card reveal">
         <div class="skill-icon">🔌</div>
         <h3>プラグイン活用力</h3>
-        <p>MCPプラグインでGmail・Drive・Calendarなど業務ツールとAIを連携できるようになる</p>
+        <p>Coworkプラグインでスキル・コネクタ・コマンドを組み合わせ、業務ツールとAIを連携できる</p>
       </div>
       <div class="skill-card reveal">
         <div class="skill-icon">📁</div>
-        <h3>業務テンプレート構築</h3>
-        <p>Projectsで自社専用のAIアシスタントを作成し、チームで共有できる</p>
+        <h3>スキル構築力</h3>
+        <p>カスタムスキルで自社専用のAIワークフローを構築し、チームで共有できる</p>
       </div>
       <div class="skill-card reveal">
         <div class="skill-icon">📊</div>


### PR DESCRIPTION
## Summary
- 業務省人化コースのカリキュラムを2026年3月時点のClaude Cowork最新機能に合わせて修正
- 「MCP」という開発者向け用語を「Coworkプラグイン・スキル」に置き換え
- スキル（Skills）機能のカリキュラムへの本格組み込み

## 変更内容
- 第2回: Coworkプラグイン体系（スキル・コネクタ・スラッシュコマンド）を教える構成に
- 第3回: カスタムスキル作成（Skill.md、Skills Directory、Plugin Create）
- 第4回: スキル×Artifactsの統合ワークフロー
- メタ情報・ヒーロー・スキルセクションの用語統一

## Test plan
- [ ] カリキュラムページの表示確認
- [ ] アコーディオン展開で修正内容が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)