### PR TITLE
fix: タブレット以下でヒーローの過剰な空白を解消

### DIFF
--- a/index.html
+++ b/index.html
@@ -957,6 +957,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
    Responsive
    ======================================== */
 @media (max-width: 1024px) {
+  .hero { min-height: auto; }
   .hero-visual { display: none; }
   .solution-grid--4col { grid-template-columns: repeat(2, 1fr); }
   .course-grid--3col { grid-template-columns: 1fr 1fr; gap: 24px; }


### PR DESCRIPTION
## Summary
- 1024px以下で `.hero { min-height: auto; }` を追加
- hero-visualが非表示になる画面幅で、100vhの空白が発生していた問題を修正

## Test plan
- [ ] タブレット幅（820px程度）でヒーロー下に過剰な空白がないこと
- [ ] デスクトップ幅（1200px+）で従来通り100vh表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)