### PR TITLE
fix: ヒーローの過剰な空白を完全解消

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,7 +199,6 @@ button { cursor: pointer; border: none; font-family: inherit; }
    Hero
    ======================================== */
 .hero {
-  min-height: 100vh;
   display: flex; align-items: flex-start;
   background: var(--gradient-hero);
   position: relative;
@@ -957,7 +956,6 @@ button { cursor: pointer; border: none; font-family: inherit; }
    Responsive
    ======================================== */
 @media (max-width: 1024px) {
-  .hero { min-height: auto; }
   .hero-visual { display: none; }
   .solution-grid--4col { grid-template-columns: repeat(2, 1fr); }
   .course-grid--3col { grid-template-columns: 1fr 1fr; gap: 24px; }


### PR DESCRIPTION
## Summary
- `.hero { min-height: 100vh; }` を完全削除
- hero-visualがposition:absoluteでフロー高さに寄与しないため、全画面幅で空白が発生していた
- PR #16の修正（1024px以下のみauto）では不十分だったため、根本対応

## Test plan
- [ ] デスクトップ幅でヒーロー下に過剰な空白がないこと
- [ ] タブレット幅でも同様に解消されていること
- [ ] ヒーローコンテンツ（バッジ〜トラスト）が適切なpaddingで表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)