### PR TITLE
fix: Google AIコースのCanvas共有記載を正確な情報に修正

### DIFF
--- a/courses/google-ai.html
+++ b/courses/google-ai.html
@@ -823,11 +823,11 @@ button { cursor: pointer; border: none; font-family: inherit; }
                 <div class="curriculum-topic"><span class="check">✓</span> Gemini Canvasとは何か — 概要と特徴</div>
                 <div class="curriculum-topic"><span class="check">✓</span> Geminiへの指示の出し方（プロンプトの基本）</div>
                 <div class="curriculum-topic"><span class="check">✓</span> Canvas上でシンプルなWebアプリを作成</div>
-                <div class="curriculum-topic"><span class="check">✓</span> プレビューと共有の方法（g.co/gemini/share）</div>
+                <div class="curriculum-topic"><span class="check">✓</span> プレビューとZIPエクスポートの方法</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>自己紹介ページをAIだけで作成し、共有リンクで公開する</p>
+                <p>自己紹介ページをAIだけで作成し、プレビューで動作確認する</p>
               </div>
             </div>
           </div>
@@ -904,10 +904,10 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> Gemini Canvas作品の共有方法</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Canvas作品のエクスポート（ZIP / GitHub連携）</div>
                 <div class="curriculum-topic"><span class="check">✓</span> Netlify Dropで無料デプロイ</div>
+                <div class="curriculum-topic"><span class="check">✓</span> 個人アカウントでの共有リンクとWorkspace制限の理解</div>
                 <div class="curriculum-topic"><span class="check">✓</span> AI StudioからCloud Runへのデプロイ概要</div>
-                <div class="curriculum-topic"><span class="check">✓</span> カスタムドメインの設定基礎</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>


### PR DESCRIPTION
## Summary
- Gemini CanvasのGoogle Workspace制限を反映
  - Workspaceアカウントでは共有リンク作成不可
  - ZIPエクスポート/GitHub連携が主要な共有手段
- 第1回: `g.co/gemini/share` 表記削除、ZIPエクスポートに変更
- 第4回: エクスポート方法と共有制限の理解を学習項目に追加

## Test plan
- [ ] 第1回・第4回の学習内容が正確に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)