### PR TITLE
fix: Google AIコースの記載を受講者目線に修正

### DIFF
--- a/courses/google-ai.html
+++ b/courses/google-ai.html
@@ -823,7 +823,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
                 <div class="curriculum-topic"><span class="check">✓</span> Gemini Canvasとは何か — 概要と特徴</div>
                 <div class="curriculum-topic"><span class="check">✓</span> Geminiへの指示の出し方（プロンプトの基本）</div>
                 <div class="curriculum-topic"><span class="check">✓</span> Canvas上でシンプルなWebアプリを作成</div>
-                <div class="curriculum-topic"><span class="check">✓</span> プレビューとZIPエクスポートの方法</div>
+                <div class="curriculum-topic"><span class="check">✓</span> 作ったアプリをプレビューで動かしてみる</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
@@ -904,10 +904,10 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> Canvas作品のエクスポート（ZIP / GitHub連携）</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Netlify Dropで無料デプロイ</div>
-                <div class="curriculum-topic"><span class="check">✓</span> 個人アカウントでの共有リンクとWorkspace制限の理解</div>
-                <div class="curriculum-topic"><span class="check">✓</span> AI StudioからCloud Runへのデプロイ概要</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Canvasで作ったアプリを外部に公開する方法</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Netlify Dropでドラッグ&ドロップ公開</div>
+                <div class="curriculum-topic"><span class="check">✓</span> AI Studio BuildからCloud Runへのデプロイ</div>
+                <div class="curriculum-topic"><span class="check">✓</span> 公開したアプリのURLをチームに共有する</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>


### PR DESCRIPTION
## Summary
- 第1回: ZIPエクスポート表記削除→プレビュー体験に集中
- 第4回: 技術用語中心→受講者が理解できる表現に変更

## Test plan
- [ ] 第1回・第4回の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)