### PR TITLE
fix: Claude Codeコース全5回のカリキュラムを再構成

### DIFF
--- a/courses/claude-code.html
+++ b/courses/claude-code.html
@@ -812,7 +812,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">Claude Codeとの初対面</span>
+              <span class="curriculum-theme">環境構築 — Claude Codeを使える状態にする</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -821,13 +821,13 @@ button { cursor: pointer; border: none; font-family: inherit; }
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
                 <div class="curriculum-topic"><span class="check">✓</span> Claude Codeとは — AI自律実行エージェントの概要</div>
-                <div class="curriculum-topic"><span class="check">✓</span> 環境セットアップ（ターミナル基礎、Claude Code導入）</div>
-                <div class="curriculum-topic"><span class="check">✓</span> 最初のプロジェクト作成とプロンプトの書き方</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Permission Systemとplan modeの基本</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Anthropicアカウントの登録と料金プラン・制限の理解</div>
+                <div class="curriculum-topic"><span class="check">✓</span> VS Codeの導入とプロジェクトフォルダの作成</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Claude Codeのインストール（OS別の手順と注意点）</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>HTMLのランディングページをClaude Codeに作らせ、ローカルで確認する</p>
+                <p>全員がClaude Codeを起動し、最初の指示を出して応答を確認する</p>
               </div>
             </div>
           </div>
@@ -840,7 +840,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">Firebase Hostingで世界に公開</span>
+              <span class="curriculum-theme">最初のアプリを作る — プロンプトと権限管理</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -848,14 +848,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> Firebaseプロジェクトの作成と初期設定</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Firebase CLIの基本操作</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Claude Codeからのデプロイコマンド実行</div>
-                <div class="curriculum-topic"><span class="check">✓</span> ホスティング設定とプレビューURL</div>
+                <div class="curriculum-topic"><span class="check">✓</span> プロンプトの書き方 — Claude Codeへの効果的な指示</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Permission System — AIの操作を承認する仕組み</div>
+                <div class="curriculum-topic"><span class="check">✓</span> plan mode — 複雑なタスクを計画してから実行する</div>
+                <div class="curriculum-topic"><span class="check">✓</span> プロジェクトの作成とファイル構成の理解</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>第1回で作ったページをFirebase Hostingにデプロイし、公開URLを取得する</p>
+                <p>Claude Codeに業務知識クイズアプリを作らせ、ローカルで動作確認する</p>
               </div>
             </div>
           </div>
@@ -868,7 +868,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">Firestoreでデータを永続化する</span>
+              <span class="curriculum-theme">Firebase連携 — デプロイとデータ保存</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -876,14 +876,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> Firestoreとは — NoSQLデータベースの基礎</div>
-                <div class="curriculum-topic"><span class="check">✓</span> データの読み書き（CRUD操作）</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Firebaseとは — アプリ開発基盤の全体像</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Firebase Hostingでアプリを公開する</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Firestoreでデータを保存・取得する</div>
                 <div class="curriculum-topic"><span class="check">✓</span> セキュリティルールの基礎設定</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Claude CodeのFirebase連携活用</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>お問い合わせフォーム付きWebアプリを作成し、データをFirestoreに保存する</p>
+                <p>第2回で作ったアプリをFirebase Hostingで公開し、Firestoreでデータ保存を追加する</p>
               </div>
             </div>
           </div>
@@ -896,7 +896,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">GitHubでチーム開発の基礎</span>
+              <span class="curriculum-theme">GitHub連携とバージョン管理</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -904,14 +904,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> Gitの基本概念（コミット・ブランチ・プルリクエスト）</div>
-                <div class="curriculum-topic"><span class="check">✓</span> GitHub連携の設定とリポジトリ作成</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Claude Codeによるコミットメッセージ自動生成</div>
-                <div class="curriculum-topic"><span class="check">✓</span> コードレビューの考え方</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Gitとは — なぜバージョン管理が必要か</div>
+                <div class="curriculum-topic"><span class="check">✓</span> GitHubアカウント作成とリポジトリの基本</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Claude Codeからのコミット・プッシュ操作</div>
+                <div class="curriculum-topic"><span class="check">✓</span> 変更履歴の確認と過去の状態に戻す方法</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>GitHubリポジトリにプロジェクトを公開し、PRを作成する</p>
+                <p>アプリのコードをGitHubに公開し、変更→コミット→履歴確認の流れを体験する</p>
               </div>
             </div>
           </div>
@@ -924,7 +924,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">GCP/Vertex AI概要 + 総合演習</span>
+              <span class="curriculum-theme">実践開発 + 修了制作</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -932,14 +932,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> Google Cloudプラットフォームの全体像</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Vertex AIとGemini APIの位置づけ</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Firebase Authenticationの基礎</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Cloud Functionsの概要</div>
+                <div class="curriculum-topic"><span class="check">✓</span> 仕様書駆動 — 仕様を定義してからClaude Codeに作らせる</div>
+                <div class="curriculum-topic"><span class="check">✓</span> 自分の業務課題をアプリ化する実践</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Claude Codeでできること・できないことの整理</div>
+                <div class="curriculum-topic"><span class="check">✓</span> 修了制作の発表とフィードバック</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>5回の総復習 — 修了制作を発表し、フィードバックを受ける</p>
+                <p>自分の業務課題をアプリ化した修了制作を発表し、「次に何をすべきか」を明確にする</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- 第1回: 詰め込みすぎ→環境構築に集中（OS別インストール、料金体系、VS Code）
- 第2回: Firebase→プロンプト・Permission System・最初のアプリ作成
- 第3回: Firestore単独→Firebase連携（Hosting公開+Firestoreデータ保存）
- 第4回: GitHub連携をより基礎的な内容に調整
- 第5回: GCP/Vertex AI→仕様書駆動の実践+修了制作

## Test plan
- [ ] 全5回の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)