### PR TITLE
fix: Claude Codeコース全5回を実践ベースで全面再構成

### DIFF
--- a/courses/claude-code.html
+++ b/courses/claude-code.html
@@ -812,7 +812,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">環境構築 — Claude Codeを使える状態にする</span>
+              <span class="curriculum-theme">環境構築 — 開発に必要なツールを全て揃える</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -821,13 +821,13 @@ button { cursor: pointer; border: none; font-family: inherit; }
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
                 <div class="curriculum-topic"><span class="check">✓</span> Claude Codeとは — AI自律実行エージェントの概要</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Anthropicアカウントの登録と料金プラン・制限の理解</div>
-                <div class="curriculum-topic"><span class="check">✓</span> VS Codeの導入とプロジェクトフォルダの作成</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Claude Codeのインストール（OS別の手順と注意点）</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Anthropicアカウント登録・プラン契約・料金と制限の理解</div>
+                <div class="curriculum-topic"><span class="check">✓</span> VS Code導入 + Claude Codeインストール（OS別の手順）</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Claude Codeでgcloud CLI・gh CLIを導入し、承認操作を体験</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>全員がClaude Codeを起動し、最初の指示を出して応答を確認する</p>
+                <p>Claude Codeを起動し、自然言語の指示でGCP・GitHubのCLIツールを導入する（承認操作の初体験）</p>
               </div>
             </div>
           </div>
@@ -840,7 +840,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">最初のアプリを作る — プロンプトと権限管理</span>
+              <span class="curriculum-theme">最初のアプリを作る — 作って公開する感動</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -848,14 +848,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> プロンプトの書き方 — Claude Codeへの効果的な指示</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Permission System — AIの操作を承認する仕組み</div>
-                <div class="curriculum-topic"><span class="check">✓</span> plan mode — 複雑なタスクを計画してから実行する</div>
-                <div class="curriculum-topic"><span class="check">✓</span> プロジェクトの作成とファイル構成の理解</div>
+                <div class="curriculum-topic"><span class="check">✓</span> 自然言語でアプリを作らせる — プロンプトの基本</div>
+                <div class="curriculum-topic"><span class="check">✓</span> ローカルで動作確認する方法</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Firebase Hostingでアプリを世界に公開する</div>
+                <div class="curriculum-topic"><span class="check">✓</span> GitHubにコードをプッシュして管理する</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>Claude Codeに業務知識クイズアプリを作らせ、ローカルで動作確認する</p>
+                <p>Claude Codeにアプリを作らせ、Firebase Hostingで公開し、GitHubにプッシュするまでを体験する</p>
               </div>
             </div>
           </div>
@@ -868,7 +868,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">Firebase連携 — デプロイとデータ保存</span>
+              <span class="curriculum-theme">間違わない作り方 — コンテキストエンジニアリング</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -876,14 +876,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> Firebaseとは — アプリ開発基盤の全体像</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Firebase Hostingでアプリを公開する</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Firestoreでデータを保存・取得する</div>
-                <div class="curriculum-topic"><span class="check">✓</span> セキュリティルールの基礎設定</div>
+                <div class="curriculum-topic"><span class="check">✓</span> なぜ「なんとなく指示」だと失敗するのか</div>
+                <div class="curriculum-topic"><span class="check">✓</span> コンテキストエンジニアリング — AIに正しい情報を渡す技術</div>
+                <div class="curriculum-topic"><span class="check">✓</span> PRD（要件定義書）をAIと一緒に作る</div>
+                <div class="curriculum-topic"><span class="check">✓</span> ADR（設計判断記録）で「なぜこう作ったか」を残す</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>第2回で作ったアプリをFirebase Hostingで公開し、Firestoreでデータ保存を追加する</p>
+                <p>PRDを作成してからアプリを作り直し、第2回の「なんとなく指示」との品質差を体験する</p>
               </div>
             </div>
           </div>
@@ -896,7 +896,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">GitHub連携とバージョン管理</span>
+              <span class="curriculum-theme">データ保存と認証 — セキュリティの重要性</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -904,14 +904,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> Gitとは — なぜバージョン管理が必要か</div>
-                <div class="curriculum-topic"><span class="check">✓</span> GitHubアカウント作成とリポジトリの基本</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Claude Codeからのコミット・プッシュ操作</div>
-                <div class="curriculum-topic"><span class="check">✓</span> 変更履歴の確認と過去の状態に戻す方法</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Firestoreでアプリにデータ保存機能を追加する</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Firebase Authenticationでログイン機能を追加する</div>
+                <div class="curriculum-topic"><span class="check">✓</span> AI駆動開発におけるセキュリティの重要性</div>
+                <div class="curriculum-topic"><span class="check">✓</span> セキュリティルール — 誰がデータにアクセスできるかを管理する</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>アプリのコードをGitHubに公開し、変更→コミット→履歴確認の流れを体験する</p>
+                <p>アプリにデータ保存とログイン機能を追加し、認証なしではアクセスできないことを確認する</p>
               </div>
             </div>
           </div>
@@ -932,8 +932,8 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> 仕様書駆動 — 仕様を定義してからClaude Codeに作らせる</div>
                 <div class="curriculum-topic"><span class="check">✓</span> 自分の業務課題をアプリ化する実践</div>
+                <div class="curriculum-topic"><span class="check">✓</span> PRD作成 → 開発 → デプロイ → GitHub管理の一連の流れ</div>
                 <div class="curriculum-topic"><span class="check">✓</span> Claude Codeでできること・できないことの整理</div>
                 <div class="curriculum-topic"><span class="check">✓</span> 修了制作の発表とフィードバック</div>
               </div>
@@ -959,32 +959,32 @@ button { cursor: pointer; border: none; font-family: inherit; }
       <div class="skill-card reveal">
         <div class="skill-icon">🤖</div>
         <h3>AI自律実行の活用力</h3>
-        <p>Claude Codeに的確な指示を出し、AIがコードを書く体験を通じて開発の全体像が理解できる</p>
+        <p>Claude Codeに自然言語で指示し、アプリ開発からデプロイまでを自律的に進められる</p>
+      </div>
+      <div class="skill-card reveal">
+        <div class="skill-icon">📋</div>
+        <h3>コンテキストエンジニアリング</h3>
+        <p>PRD/ADRを活用し、AIに正しい情報を渡して品質の高い成果物を得る技術が身につく</p>
       </div>
       <div class="skill-card reveal">
         <div class="skill-icon">🔥</div>
         <h3>Firebase活用スキル</h3>
-        <p>Firebase HostingとFirestoreを使い、アプリの公開からデータ管理までできるようになる</p>
+        <p>Hosting・Firestore・Authenticationを使い、公開・データ保存・認証まで構築できる</p>
       </div>
       <div class="skill-card reveal">
-        <div class="skill-icon">📊</div>
-        <h3>データベース基礎</h3>
-        <p>Firestoreでのデータモデリング、CRUD操作、セキュリティルール設定が理解できる</p>
+        <div class="skill-icon">🔒</div>
+        <h3>セキュリティの理解</h3>
+        <p>AI駆動開発における認証・認可・セキュリティルールの重要性を理解し実践できる</p>
       </div>
       <div class="skill-card reveal">
         <div class="skill-icon">🔀</div>
         <h3>Git/GitHub連携</h3>
-        <p>バージョン管理の基本とGitHubでのチーム開発フローが身につく</p>
-      </div>
-      <div class="skill-card reveal">
-        <div class="skill-icon">☁️</div>
-        <h3>GCP基礎知識</h3>
-        <p>Google Cloud、Vertex AI、Gemini APIの全体像を理解し、次のステップが見える</p>
+        <p>バージョン管理の基本とGitHubでのコード管理フローが身につく</p>
       </div>
       <div class="skill-card reveal">
         <div class="skill-icon">🚀</div>
-        <h3>デプロイスキル</h3>
-        <p>作ったアプリをFirebase Hostingで本番公開し、世界中からアクセスできる状態にできる</p>
+        <h3>開発の一連の流れ</h3>
+        <p>PRD作成→開発→デプロイ→GitHub管理まで、AI駆動開発の全工程を一人で回せる</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- 全5回のカリキュラムを実践ベースで全面再構成
- 第1回: 環境構築にGCP/GitHub CLIツール導入を含め、承認操作を自然に体験
- 第2回: アプリ作成→公開→GitHub管理の感動体験に集中
- 第3回: コンテキストエンジニアリング（PRD/ADR）を丁寧に
- 第4回: Firestore+Auth+セキュリティの重要性
- 第5回: 実践開発+修了制作
- スキルセクションも全面更新

## Test plan
- [ ] 全5回+スキルセクションの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)