### PR TITLE
fix: Claude Codeコースにプラグイン・ハーネスエンジニアリングを組み込み

### DIFF
--- a/courses/claude-code.html
+++ b/courses/claude-code.html
@@ -849,13 +849,13 @@ button { cursor: pointer; border: none; font-family: inherit; }
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
                 <div class="curriculum-topic"><span class="check">✓</span> 自然言語でアプリを作らせる — プロンプトの基本</div>
-                <div class="curriculum-topic"><span class="check">✓</span> ローカルで動作確認する方法</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Frontend Designプラグインで見た目を本格的に仕上げる</div>
                 <div class="curriculum-topic"><span class="check">✓</span> Firebase Hostingでアプリを世界に公開する</div>
                 <div class="curriculum-topic"><span class="check">✓</span> GitHubにコードをプッシュして管理する</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>Claude Codeにアプリを作らせ、Firebase Hostingで公開し、GitHubにプッシュするまでを体験する</p>
+                <p>Claude Code + Frontend Designでアプリを作り、Firebase公開・GitHubプッシュまでを体験する</p>
               </div>
             </div>
           </div>
@@ -878,12 +878,12 @@ button { cursor: pointer; border: none; font-family: inherit; }
               <div class="curriculum-topics">
                 <div class="curriculum-topic"><span class="check">✓</span> なぜ「なんとなく指示」だと失敗するのか</div>
                 <div class="curriculum-topic"><span class="check">✓</span> コンテキストエンジニアリング — AIに正しい情報を渡す技術</div>
-                <div class="curriculum-topic"><span class="check">✓</span> PRD（要件定義書）をAIと一緒に作る</div>
-                <div class="curriculum-topic"><span class="check">✓</span> ADR（設計判断記録）で「なぜこう作ったか」を残す</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Feature Devプラグインで探索→設計→実装の流れを体験</div>
+                <div class="curriculum-topic"><span class="check">✓</span> PRD / CLAUDE.md — AIへの指示と制約を文書で管理する</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>PRDを作成してからアプリを作り直し、第2回の「なんとなく指示」との品質差を体験する</p>
+                <p>Feature Devでアプリを設計し直し、第2回の「なんとなく指示」との品質差を体験する</p>
               </div>
             </div>
           </div>
@@ -904,10 +904,10 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> Firestoreでアプリにデータ保存機能を追加する</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Firebase Authenticationでログイン機能を追加する</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Firestoreでデータ保存 + Authenticationでログイン機能</div>
                 <div class="curriculum-topic"><span class="check">✓</span> AI駆動開発におけるセキュリティの重要性</div>
-                <div class="curriculum-topic"><span class="check">✓</span> セキュリティルール — 誰がデータにアクセスできるかを管理する</div>
+                <div class="curriculum-topic"><span class="check">✓</span> プラグインの仕組み — hooks / skills / MCPで構成されている</div>
+                <div class="curriculum-topic"><span class="check">✓</span> AIと対話しながらプラグインをカスタマイズする方法</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>


### PR DESCRIPTION
## Summary
- 第2回: Frontend Designプラグインでアプリの見た目を本格化
- 第3回: Feature Devプラグインで探索→設計→実装 + CLAUDE.md導入
- 第4回: プラグインの仕組み（hooks/skills/MCP）の理解とカスタマイズ
- Claude Codeならではの機能に各回で段階的に触れる構成

## Test plan
- [ ] 第2回・第3回・第4回の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)