### PR TITLE
fix: 業務省人化コースのカリキュラムをClaude Desktop/Cowork最新情報で全面再構成

### DIFF
--- a/courses/business-automation.html
+++ b/courses/business-automation.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>非エンジニアのための業務省人化 | AI開発講座</title>
-<meta name="description" content="Claude Coworkのプラグインとスキルで、日々の業務を自動化。プログラミング不要。2時間×5回の集中研修。リスキリング補助金対応で自己負担9万円。">
+<meta name="description" content="Claude Desktopで日々の業務を自動化。チャット・Coworkモードを使いこなし、コネクタ・プラグイン・スキルで業務効率化。プログラミング不要。2時間×5回の集中研修。リスキリング補助金対応で自己負担9万円。">
 <meta property="og:title" content="非エンジニアのための業務省人化 | AI開発講座">
-<meta property="og:description" content="Claude Coworkで業務自動化。プラグインとスキルで業務ツールと連携、定型業務を効率化。リスキリング補助金対応。">
+<meta property="og:description" content="Claude Desktopで業務自動化。チャットモードからCoworkモードまで段階的に学び、コネクタ・プラグイン・スキルで定型業務を効率化。リスキリング補助金対応。">
 <meta property="og:type" content="website">
 <link rel="icon" type="image/svg+xml" href="../favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -740,7 +740,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
       非エンジニアのための<br>業務省人化
     </h1>
     <p class="course-hero-sub">
-      Claude Coworkのプラグインとスキルで、日々の業務を自動化。<br>
+      Claude Desktopのチャットモードで文書作成、Coworkモードで業務自動化。<br>
       プログラミング経験は一切不要。AIに日本語で指示するだけで、<br>
       メール整理・資料作成・データ分析を効率化できます。
     </p>
@@ -812,7 +812,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">AIと一緒に働く新しいスタイル</span>
+              <span class="curriculum-theme">Claude Desktopとの初対面</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -820,14 +820,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> Claude Desktopの基本操作とセットアップ</div>
-                <div class="curriculum-topic"><span class="check">✓</span> AIへの効果的な指示の出し方（プロンプト基礎）</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Artifactsで文書・表・グラフを作成</div>
-                <div class="curriculum-topic"><span class="check">✓</span> ファイルのアップロードと分析</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Claude Desktopのインストールとセットアップ</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Anthropicアカウント作成・Proプランの契約と料金体系</div>
+                <div class="curriculum-topic"><span class="check">✓</span> チャットモードの基本 — プロンプトの書き方・Artifacts・ファイル作成</div>
+                <div class="curriculum-topic"><span class="check">✓</span> チャット / Cowork / コード — 3つのモードの違いを理解する</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>会議議事録のテンプレートをAIに作らせ、実際の議事録を整理する</p>
+                <p>チャットモードでArtifactsを使い業務日報テンプレートを作成、ファイル作成機能で.docxに出力する</p>
               </div>
             </div>
           </div>
@@ -840,7 +840,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">プラグインとスキルで業務ツールとつなげる</span>
+              <span class="curriculum-theme">コネクタで業務ツールとつなげる</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -848,14 +848,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> Coworkプラグインとは — スキル・コネクタ・コマンドのバンドル</div>
-                <div class="curriculum-topic"><span class="check">✓</span> プラグインマーケットプレイスからのインストール</div>
-                <div class="curriculum-topic"><span class="check">✓</span> コネクタでGoogle Drive・Gmail・Slackと連携</div>
-                <div class="curriculum-topic"><span class="check">✓</span> スラッシュコマンド（/）でスキルを呼び出す実践</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Coworkモードに入る — マルチステップタスクの自律実行とは</div>
+                <div class="curriculum-topic"><span class="check">✓</span> コネクタの仕組みと設定（Google Drive・Gmail等）</div>
+                <div class="curriculum-topic"><span class="check">✓</span> ファイルのアップロードと分析 — PDFやExcelの中身をAIに読ませる</div>
+                <div class="curriculum-topic"><span class="check">✓</span> コネクタ経由でクラウド上の資料を直接操作する</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>プラグインを導入し、Google Driveの資料をAIに要約させ、報告メールの下書きを作成する</p>
+                <p>Google Driveの資料をコネクタ経由でAIに要約させ、報告メールの下書きを作成する</p>
               </div>
             </div>
           </div>
@@ -868,7 +868,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">スキルで「自分専用AI」を作る</span>
+              <span class="curriculum-theme">プラグインで専門AIに変える</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -876,14 +876,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> スキルとは — 業務知識をAIに教え込む仕組み</div>
-                <div class="curriculum-topic"><span class="check">✓</span> カスタムスキルの作り方（Skill.md + ZIP）</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Skills Directoryから業種別スキルを導入</div>
-                <div class="curriculum-topic"><span class="check">✓</span> Projectsと組み合わせて知識ベースを構築</div>
+                <div class="curriculum-topic"><span class="check">✓</span> プラグインとは — スキル・コネクタ・コマンドのバンドル</div>
+                <div class="curriculum-topic"><span class="check">✓</span> プラグインマーケットプレイスからの導入方法</div>
+                <div class="curriculum-topic"><span class="check">✓</span> 業種・部門別プラグインの活用（営業・経理・人事・総務等）</div>
+                <div class="curriculum-topic"><span class="check">✓</span> スラッシュコマンド（/）でスキルを呼び出す実践</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>自社FAQ対応のカスタムスキルを作成し、スラッシュコマンドで呼び出せるようにする</p>
+                <p>自社業務に合うプラグインを導入し、スラッシュコマンドで実務タスクを実行する</p>
               </div>
             </div>
           </div>
@@ -896,7 +896,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">スキル × Artifactsで業務を自動化する</span>
+              <span class="curriculum-theme">スキルとProjectsで「自分専用AI」を作る</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -904,14 +904,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> Artifactsで.docx / .xlsx / .pptxを自動生成</div>
-                <div class="curriculum-topic"><span class="check">✓</span> スキルで定型業務をテンプレート化</div>
-                <div class="curriculum-topic"><span class="check">✓</span> 報告書・提案書の自動ドラフト作成</div>
-                <div class="curriculum-topic"><span class="check">✓</span> カスタムプラグインの作成（Plugin Create）</div>
+                <div class="curriculum-topic"><span class="check">✓</span> /skill-creatorでカスタムスキルを作成する</div>
+                <div class="curriculum-topic"><span class="check">✓</span> Projectsで永続ワークスペースを構築（メモリ・ファイル・指示）</div>
+                <div class="curriculum-topic"><span class="check">✓</span> スケジュールタスクで定期業務を自動化（毎朝ブリーフィング等）</div>
+                <div class="curriculum-topic"><span class="check">✓</span> スキル × ファイル作成で定型レポートを一発生成</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
-                <p>月次報告書スキルを作成し、スラッシュコマンド一発でドラフトを自動生成する</p>
+                <p>自社FAQ対応のカスタムスキルを作成し、Projectsに登録して繰り返し使える環境を構築する</p>
               </div>
             </div>
           </div>
@@ -924,7 +924,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <div class="curriculum-card" onclick="toggleCurriculum(this)">
           <div class="curriculum-header">
             <div>
-              <span class="curriculum-theme">コワークスタイル実践 + 総まとめ</span>
+              <span class="curriculum-theme">実践ワークフロー + 次のステップ</span>
               <span class="curriculum-duration">2時間</span>
             </div>
             <span class="curriculum-arrow">▼</span>
@@ -932,10 +932,10 @@ button { cursor: pointer; border: none; font-family: inherit; }
           <div class="curriculum-details">
             <div class="curriculum-details-inner">
               <div class="curriculum-topics">
-                <div class="curriculum-topic"><span class="check">✓</span> 複数のスキル・プラグインを組み合わせたワークフロー</div>
-                <div class="curriculum-topic"><span class="check">✓</span> 部署別の活用事例（営業・経理・人事・総務）</div>
+                <div class="curriculum-topic"><span class="check">✓</span> コネクタ × プラグイン × スキルを組み合わせたワークフロー設計</div>
                 <div class="curriculum-topic"><span class="check">✓</span> セキュリティとプライバシーの注意点</div>
-                <div class="curriculum-topic"><span class="check">✓</span> 社内展開のステップ</div>
+                <div class="curriculum-topic"><span class="check">✓</span> 社内展開のステップと部署別活用事例</div>
+                <div class="curriculum-topic"><span class="check">✓</span> さらにその先へ — Claude Code（CLI）という上位互換の紹介</div>
               </div>
               <div class="curriculum-exercise">
                 <div class="curriculum-exercise-label">Hands-on</div>
@@ -962,24 +962,24 @@ button { cursor: pointer; border: none; font-family: inherit; }
         <p>Claude Desktopに的確な指示を出し、望む結果を得るプロンプト技術が身につく</p>
       </div>
       <div class="skill-card reveal">
+        <div class="skill-icon">🔗</div>
+        <h3>コネクタ活用力</h3>
+        <p>Google Drive・Gmail等のコネクタを設定し、クラウド上の業務データをAIと連携できる</p>
+      </div>
+      <div class="skill-card reveal">
         <div class="skill-icon">🔌</div>
         <h3>プラグイン活用力</h3>
-        <p>Coworkプラグインでスキル・コネクタ・コマンドを組み合わせ、業務ツールとAIを連携できる</p>
+        <p>マーケットプレイスから業種・部門別プラグインを導入し、AIを専門家に変えられる</p>
       </div>
       <div class="skill-card reveal">
         <div class="skill-icon">📁</div>
-        <h3>スキル構築力</h3>
-        <p>カスタムスキルで自社専用のAIワークフローを構築し、チームで共有できる</p>
+        <h3>カスタムスキル構築</h3>
+        <p>/skill-creatorで自社専用のスキルを作成し、Projectsで知識ベースを構築できる</p>
       </div>
       <div class="skill-card reveal">
         <div class="skill-icon">📊</div>
         <h3>自動レポート作成</h3>
-        <p>Artifactsで報告書・提案書・データ分析を自動生成できるようになる</p>
-      </div>
-      <div class="skill-card reveal">
-        <div class="skill-icon">🔄</div>
-        <h3>ワークフロー設計</h3>
-        <p>複数のAIツール・プラグインを組み合わせた業務自動化フローが設計できる</p>
+        <p>ファイル作成機能で報告書(.docx)・データ分析(.xlsx)・提案書(.pptx)を自動生成できる</p>
       </div>
       <div class="skill-card reveal">
         <div class="skill-icon">🏢</div>
@@ -1017,10 +1017,10 @@ button { cursor: pointer; border: none; font-family: inherit; }
       <div class="overview-card reveal">
         <h3>必要な準備</h3>
         <ul>
-          <li>Anthropicアカウント（Claude Desktop用）</li>
+          <li>PCとインターネット環境（Windows / Mac）</li>
           <li>Googleアカウント（Drive・Gmail連携用）</li>
-          <li>PCとインターネット環境</li>
-          <li>プログラミング経験は不要</li>
+          <li>クレジットカード（Anthropic Proプラン $20/月の契約に使用）</li>
+          <li>プログラミング経験は不要（アカウント登録は研修内でサポート）</li>
         </ul>
       </div>
       <div class="overview-card reveal">


### PR DESCRIPTION
## Summary
- 業務省人化コース全5回を2026年3月時点のClaude Desktop/Cowork公式情報に基づき全面再構成
- チャットモード→Coworkモードへの段階的ステップアップ構成に変更
- 旧カリキュラムの不正確な用語（Artifacts→ファイル作成、Plugin Create→/skill-creator、Skills Directory→マーケットプレイス）を修正
- 最新機能（Projects、スケジュールタスク）を追加し、最終回でClaude Code（CLI）への導線を設置

## 変更内容
- 第1回: AIと一緒に働く → Claude Desktopとの初対面（チャットモード基本+3モード紹介）
- 第2回: プラグインとスキル → コネクタで業務ツールとつなげる
- 第3回: スキルで自分専用AI → プラグインで専門AIに変える
- 第4回: スキル×Artifacts → スキルとProjectsで「自分専用AI」を作る
- 第5回: コワークスタイル → 実践ワークフロー + 次のステップ（Claude Code紹介）
- スキルセクション: コネクタ活用力・カスタムスキル構築を追加
- 必要な準備: Proプラン($20/月)・クレジットカード要件を明記
- メタ情報（description/og:description）更新

## Test plan
- [x] ローカルで全セクション表示確認
- [x] カリキュラム全5回のアコーディオン展開確認
- [x] スキルセクション6項目の表示確認
- [x] 受講概要（必要な準備）の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)