### PR TITLE
fix: LPトップの業務省人化コースカード・FAQをカリキュラム刷新に合わせて更新

### DIFF
--- a/index.html
+++ b/index.html
@@ -1227,7 +1227,7 @@ AI: 承知しました。
       <div class="course-card reveal">
         <span class="course-badge">AUTOMATION</span>
         <h3 class="course-name">非エンジニアのための<br>業務省人化</h3>
-        <p class="course-desc">コワーク（プラグイン・スキル）を活用して、日々の業務を自動化。エンジニア経験不要。</p>
+        <p class="course-desc">Claude Desktopのチャットモードで文書作成、Coworkモードでコネクタ・プラグイン・スキルを活用した業務自動化。エンジニア経験不要。</p>
         <div class="course-price">
           <span class="original">&#165;400,000</span>
           <div><span class="actual"><span class="yen">&#165;</span>90,000</span> <span class="period">/ 全5回</span></div>
@@ -1235,10 +1235,10 @@ AI: 承知しました。
         <div class="subsidy-tag">&#127891; リスキリング補助金適用時の自己負担額</div>
         <ul class="course-features">
           <li><span class="check">&#10003;</span>2時間 × 5回の集中研修</li>
-          <li><span class="check">&#10003;</span>プラグイン・スキルでの業務自動化</li>
-          <li><span class="check">&#10003;</span>コワークスタイルで即実践</li>
+          <li><span class="check">&#10003;</span>コネクタでGoogle Drive・Gmail等と連携</li>
+          <li><span class="check">&#10003;</span>プラグイン・スキルで業務を自動化</li>
+          <li><span class="check">&#10003;</span>Projectsとスケジュールタスクで定期業務自動化</li>
           <li><span class="check">&#10003;</span>プログラミング経験不要</li>
-          <li><span class="check">&#10003;</span>自社業務に合わせたカスタマイズ</li>
         </ul>
         <p class="course-subsidy-note">1社員3回まで受講可能 | オンライン受講可</p>
         <a href="courses/business-automation.html" class="course-detail-link">カリキュラム詳細を見る &rarr;</a>
@@ -1339,7 +1339,7 @@ AI: 承知しました。
           <span class="arrow">&#9660;</span>
         </button>
         <div class="faq-answer">
-          <p>Googleでのアプリ開発コースは、Gemini CanvasとAI Studio Buildを使ったノーコード開発体験（GCP課金不要）。Claude Codeでのアプリ開発コースは、AI駆動の本格開発（環境構築・Firebase公開・GitHub管理・プラグイン活用まで）。業務省人化コースは、Claude Coworkのプラグインとスキルを使って日常業務を自動化する実践講座です。</p>
+          <p>Googleでのアプリ開発コースは、Gemini CanvasとAI Studio Buildを使ったノーコード開発体験（GCP課金不要）。Claude Codeでのアプリ開発コースは、AI駆動の本格開発（環境構築・Firebase公開・GitHub管理・プラグイン活用まで）。業務省人化コースは、Claude Desktopのチャットモードからコネクタ・プラグイン・スキルまで段階的に学び、日常業務を自動化する実践講座です。</p>
         </div>
       </div>
       <div class="faq-item reveal">


### PR DESCRIPTION
## Summary
- PR #33（業務省人化コースカリキュラム刷新）に伴い、LPトップページの関連箇所を整合性調整

## 変更内容
- コースカードdesc: 「コワーク（プラグイン・スキル）」→「チャットモード+Coworkモードで段階的学習」
- コースカードfeatures: コネクタ連携・Projects・スケジュールタスクを反映
- FAQ（3コースの違い）: 業務省人化コースの説明を新カリキュラム構成に合わせて更新

## Test plan
- [x] コースカード表示確認
- [x] FAQ表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)