### PR TITLE
fix: カード高さ統一・ボタンデザインをグラデーションに統一

### DIFF
--- a/index.html
+++ b/index.html
@@ -626,6 +626,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   display: block;
   text-align: center;
   padding: 10px 0;
+  margin-top: auto;
   margin-bottom: 12px;
   font-size: 0.875rem;
   font-weight: 600;
@@ -636,39 +637,25 @@ button { cursor: pointer; border: none; font-family: inherit; }
 .course-detail-link:hover { color: var(--c-white); }
 
 /* ---- CTA ---- */
-.course-cta {
+.course-cta,
+.enterprise-cta {
   width: 100%;
-  padding: 16px 26px;  /* 26:16 = 1.625 ≈ φ */
-  border-radius: 14px;
+  padding: 14px 26px;
+  border-radius: 100px;
   font-size: 0.938rem; font-weight: 700;
   font-family: var(--font-display);
   text-align: center;
   cursor: pointer;
-  transition:
-    box-shadow 0.3s ease,
-    transform 0.35s cubic-bezier(0.22, 1, 0.36, 1),
-    background 0.25s ease,
-    border-color 0.25s ease;
-  /* 通常カード: ゴースト */
-  background: rgba(255,255,255,0.05);
-  border: 1px solid rgba(255,255,255,0.15);
-  color: var(--c-text);
-}
-.course-cta:hover {
-  background: rgba(255,255,255,0.10);
-  border-color: rgba(255,255,255,0.28);
-  transform: translateY(-2px);
-}
-/* Featured のみ: グラデーション塗り */
-.course-card.featured .course-cta {
   background: var(--gradient-main);
   border: none;
   color: white;
-  box-shadow: 0 4px 20px rgba(0,136,255,0.15);
+  box-shadow: 0 4px 16px rgba(0,136,255,0.2);
+  transition: transform 0.3s, box-shadow 0.3s;
 }
-.course-card.featured .course-cta:hover {
-  box-shadow: 0 8px 32px rgba(0,136,255,0.25);
+.course-cta:hover,
+.enterprise-cta:hover {
   transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0,136,255,0.35);
 }
 
 /* ---- Subsidy Note (per card) ---- */
@@ -687,7 +674,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   grid-template-columns: repeat(3, 1fr);
   gap: 20px;
   margin-top: 56px;
-  align-items: start;
+  align-items: stretch;
 }
 
 /* ---- Wide card (伴走コース) ---- */
@@ -767,6 +754,10 @@ button { cursor: pointer; border: none; font-family: inherit; }
   position: relative;
   overflow: hidden;
   box-shadow: 0 4px 24px rgba(0,0,0,0.2);
+  display: flex; flex-direction: column;
+}
+.enterprise-cta {
+  margin-top: auto;
 }
 .enterprise-card::after {
   content: ''; position: absolute; top: 0; right: 0;
@@ -1220,7 +1211,7 @@ AI: 承知しました。
         </ul>
         <p class="course-subsidy-note">1社員3回まで受講可能 | オンライン受講可</p>
         <a href="courses/claude-code.html" class="course-detail-link">カリキュラム詳細を見る &rarr;</a>
-        <a href="https://4173jg.share-na2.hsforms.com/2pgu1PephQXysLrqHDoiPiw" class="course-cta primary" target="_blank" rel="noopener noreferrer">無料相談を予約する</a>
+        <button class="course-cta secondary" onclick="scrollToContact()">詳細を相談する</button>
       </div>
 
       <!-- Course 3: 業務省人化 -->
@@ -1296,6 +1287,7 @@ AI: 承知しました。
           <span>カスタム開発</span>
           <span>API連携</span>
         </div>
+        <button class="enterprise-cta" onclick="scrollToContact()">詳細を相談する</button>
       </div>
       <div class="enterprise-card reveal">
         <div class="enterprise-icon">&#128737;</div>
@@ -1311,6 +1303,7 @@ AI: 承知しました。
           <span>技術サポート</span>
           <span>月額制</span>
         </div>
+        <button class="enterprise-cta" onclick="scrollToContact()">詳細を相談する</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- コースカード3枚の高さをstretch+margin-top:autoで揃え
- 真ん中カードの「無料相談を予約する」を「詳細を相談する」に変更
- 全CTAボタンを「解決策を見る」と同じグラデーション+角丸100pxに統一
- 受託開発・保守運用カードに「詳細を相談する」ボタンを追加

## Test plan
- [ ] コースカード3枚の高さが揃っていること
- [ ] 全ボタンがグラデーションデザインで統一されていること
- [ ] 受託開発・保守運用カードに「詳細を相談する」ボタンが表示されること
- [ ] ボタンクリックでお問い合わせセクションにスクロールすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)