### PR TITLE
fix: 受講可能の表記を助成金3コース受講可能に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -1187,7 +1187,7 @@ AI: 承知しました。
           <li><span class="check">&#10003;</span>Firebase連携（データ保存・認証）</li>
           <li><span class="check">&#10003;</span>できることの限界と次のステップ</li>
         </ul>
-        <p class="course-subsidy-note">1社員3回まで受講可能 | オンライン受講可</p>
+        <p class="course-subsidy-note">1社員助成金を使って3コース受講可能 | オンライン受講可</p>
         <a href="courses/google-ai.html" class="course-detail-link">カリキュラム詳細を見る &rarr;</a>
         <button class="course-cta secondary" onclick="scrollToContact()">詳細を相談する</button>
       </div>
@@ -1209,7 +1209,7 @@ AI: 承知しました。
           <li><span class="check">&#10003;</span>プラグイン活用（Frontend Design等）</li>
           <li><span class="check">&#10003;</span>データ保存・認証・セキュリティ</li>
         </ul>
-        <p class="course-subsidy-note">1社員3回まで受講可能 | オンライン受講可</p>
+        <p class="course-subsidy-note">1社員助成金を使って3コース受講可能 | オンライン受講可</p>
         <a href="courses/claude-code.html" class="course-detail-link">カリキュラム詳細を見る &rarr;</a>
         <button class="course-cta secondary" onclick="scrollToContact()">詳細を相談する</button>
       </div>
@@ -1231,7 +1231,7 @@ AI: 承知しました。
           <li><span class="check">&#10003;</span>Projectsとスケジュールタスクで定期業務自動化</li>
           <li><span class="check">&#10003;</span>プログラミング経験不要</li>
         </ul>
-        <p class="course-subsidy-note">1社員3回まで受講可能 | オンライン受講可</p>
+        <p class="course-subsidy-note">1社員助成金を使って3コース受講可能 | オンライン受講可</p>
         <a href="courses/business-automation.html" class="course-detail-link">カリキュラム詳細を見る &rarr;</a>
         <button class="course-cta secondary" onclick="scrollToContact()">詳細を相談する</button>
       </div>


### PR DESCRIPTION
## Summary
- 「1社員3回まで受講可能」→「1社員助成金を使って3コース受講可能」に変更（3箇所）

## Test plan
- [ ] コースカード3枚すべてで表記が更新されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)