### PR TITLE
fix: 受講可能テキストを改行・中央揃えに調整

### DIFF
--- a/index.html
+++ b/index.html
@@ -666,6 +666,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   padding: 8px 0;
   border-top: 1px solid rgba(255,255,255,0.06);
   line-height: 1.6;
+  text-align: center;
 }
 
 /* ---- 3-column grid for training courses ---- */
@@ -1187,7 +1188,7 @@ AI: 承知しました。
           <li><span class="check">&#10003;</span>Firebase連携（データ保存・認証）</li>
           <li><span class="check">&#10003;</span>できることの限界と次のステップ</li>
         </ul>
-        <p class="course-subsidy-note">1社員助成金を使って3コース受講可能 | オンライン受講可</p>
+        <p class="course-subsidy-note">1社員助成金を使って3コース受講可能<br>オンライン受講可</p>
         <a href="courses/google-ai.html" class="course-detail-link">カリキュラム詳細を見る &rarr;</a>
         <button class="course-cta secondary" onclick="scrollToContact()">詳細を相談する</button>
       </div>
@@ -1209,7 +1210,7 @@ AI: 承知しました。
           <li><span class="check">&#10003;</span>プラグイン活用（Frontend Design等）</li>
           <li><span class="check">&#10003;</span>データ保存・認証・セキュリティ</li>
         </ul>
-        <p class="course-subsidy-note">1社員助成金を使って3コース受講可能 | オンライン受講可</p>
+        <p class="course-subsidy-note">1社員助成金を使って3コース受講可能<br>オンライン受講可</p>
         <a href="courses/claude-code.html" class="course-detail-link">カリキュラム詳細を見る &rarr;</a>
         <button class="course-cta secondary" onclick="scrollToContact()">詳細を相談する</button>
       </div>
@@ -1231,7 +1232,7 @@ AI: 承知しました。
           <li><span class="check">&#10003;</span>Projectsとスケジュールタスクで定期業務自動化</li>
           <li><span class="check">&#10003;</span>プログラミング経験不要</li>
         </ul>
-        <p class="course-subsidy-note">1社員助成金を使って3コース受講可能 | オンライン受講可</p>
+        <p class="course-subsidy-note">1社員助成金を使って3コース受講可能<br>オンライン受講可</p>
         <a href="courses/business-automation.html" class="course-detail-link">カリキュラム詳細を見る &rarr;</a>
         <button class="course-cta secondary" onclick="scrollToContact()">詳細を相談する</button>
       </div>


### PR DESCRIPTION
## Summary
- 「1社員助成金を使って3コース受講可能」と「オンライン受講可」を改行で分離
- テキストを中央揃えに変更

## Test plan
- [ ] 3枚のコースカードでテキストが中央揃え・2行表示になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)