### PR TITLE
fix: 全体の読みやすさを改善（フォントサイズ・コントラスト）

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
   --c-dark-card: #15151f;
   --c-dark-border: rgba(255,255,255,0.10);
   --c-text: #ededf0;
-  --c-text-muted: #a0a0b8;
+  --c-text-muted: #b0b0c8;
   --c-white: #ffffff;
   --gradient-main: linear-gradient(135deg, var(--c-red), var(--c-blue));
   --gradient-hero: linear-gradient(160deg, #0a0a1a 0%, #0d1b2a 40%, #1a0a1e 70%, #0a0a1a 100%);
@@ -114,7 +114,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
 .btn-secondary:hover { border-color: rgba(255,255,255,0.2); background: rgba(255,255,255,0.05); }
 .section-label {
   font-family: var(--font-display);
-  font-size: 0.8rem; font-weight: 700;
+  font-size: 0.85rem; font-weight: 700;
   letter-spacing: 0.18em; text-transform: uppercase;
   color: var(--c-blue);
   margin-bottom: 20px;
@@ -241,7 +241,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   border: 1px solid rgba(0,136,255,0.2);
   border-radius: 100px;
   font-family: var(--font-display);
-  font-size: 0.8rem; font-weight: 600;
+  font-size: 0.85rem; font-weight: 600;
   color: var(--c-blue);
   margin-bottom: 32px;
   animation: fadeUp 0.8s ease-out;
@@ -380,7 +380,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   line-height: 1.5;
 }
 .pain-card p {
-  font-size: 0.95rem;
+  font-size: 1rem;
   color: var(--c-text-muted);
   line-height: 1.75;
 }
@@ -390,7 +390,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   padding: 10px 20px;
   background: var(--gradient-main);
   color: white;
-  font-size: 0.85rem; font-weight: 700;
+  font-size: 0.9rem; font-weight: 700;
   font-family: var(--font-display);
   border-radius: 100px;
   transition: transform 0.3s, box-shadow 0.3s;
@@ -455,14 +455,14 @@ button { cursor: pointer; border: none; font-family: inherit; }
   margin-bottom: 13px;
 }
 .solution-card p {
-  font-size: 0.95rem;
+  font-size: 1rem;
   color: var(--c-text-muted);
   line-height: 1.85;
 }
 .solution-link {
   display: inline-block;
   margin-top: 13px;
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   font-weight: 600;
   color: var(--c-blue);
   text-decoration: none;
@@ -524,7 +524,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   display: inline-block;
   padding: 6px 16px;
   border-radius: 100px;
-  font-size: 0.75rem; font-weight: 700;
+  font-size: 0.8rem; font-weight: 700;
   font-family: var(--font-display);
   letter-spacing: 0.08em;
   margin-bottom: 20px; /* φ scale: 20px */
@@ -543,7 +543,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   margin-bottom: 13px;  /* φ scale: 13px */
 }
 .course-desc {
-  font-size: 0.938rem;
+  font-size: 1rem;
   color: var(--c-text-muted);
   margin-bottom: 32px;  /* φ scale: 32px */
   line-height: 1.8;
@@ -573,7 +573,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   background: rgba(24,165,88,0.10);
   border: 1px solid rgba(24,165,88,0.22);
   border-radius: var(--radius-sm);
-  font-size: 0.75rem; font-weight: 600;
+  font-size: 0.8rem; font-weight: 600;
   color: var(--c-green);
   margin-bottom: 32px;  /* φ scale: 32px */
 }
@@ -583,7 +583,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
 .course-features li {
   display: flex; align-items: flex-start; gap: 10px;
   padding: 10px 0;
-  font-size: 0.938rem;
+  font-size: 1rem;
   color: var(--c-text-muted);
   border-bottom: 1px solid rgba(255,255,255,0.04);
 }
@@ -602,7 +602,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   padding: 10px 0;
   margin-bottom: 12px;
   align-self: end;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
   font-weight: 600;
   color: var(--c-blue);
   transition: color 0.3s;
@@ -634,7 +634,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
 
 /* ---- Subsidy Note (per card) ---- */
 .course-subsidy-note {
-  font-size: 0.75rem;
+  font-size: 0.8rem;
   color: var(--c-text-muted);
   margin-bottom: 20px;
   padding: 8px 0;
@@ -696,7 +696,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   z-index: 1;
 }
 .course-pricing-note {
-  font-size: 0.8rem;
+  font-size: 0.875rem;
   color: var(--c-text-muted);
   margin: 12px 0 20px;
   line-height: 1.6;
@@ -768,7 +768,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   margin-bottom: 14px;
 }
 .enterprise-card p {
-  font-size: 0.95rem;
+  font-size: 1rem;
   color: var(--c-text-muted);
   line-height: 1.85;
   margin-bottom: 24px;
@@ -781,7 +781,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   background: rgba(255,255,255,0.04);
   border: 1px solid var(--c-dark-border);
   border-radius: 100px;
-  font-size: 0.82rem; font-weight: 500;
+  font-size: 0.875rem; font-weight: 500;
   color: var(--c-text-muted);
 }
 .enterprise-pricing {
@@ -800,7 +800,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
 }
 .enterprise-price-note {
   display: block;
-  font-size: 0.82rem;
+  font-size: 0.875rem;
   color: var(--c-text-muted);
 }
 
@@ -841,7 +841,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
 .faq-item.active .faq-answer { max-height: var(--faq-height, 300px); }
 .faq-answer p {
   padding-bottom: 24px;
-  font-size: 0.95rem;
+  font-size: 1rem;
   color: var(--c-text-muted);
   line-height: 1.9;
 }
@@ -879,11 +879,11 @@ button { cursor: pointer; border: none; font-family: inherit; }
   margin-bottom: 48px;
 }
 .footer-brand .nav-logo { margin-bottom: 16px; }
-.footer-brand p { font-size: 0.9rem; color: var(--c-text-muted); max-width: 300px; line-height: 1.8; }
+.footer-brand p { font-size: 0.925rem; color: var(--c-text-muted); max-width: 300px; line-height: 1.8; }
 .footer-links { display: flex; gap: 64px; }
 .footer-links-group h4 {
   font-family: var(--font-display);
-  font-size: 0.75rem; font-weight: 700;
+  font-size: 0.8rem; font-weight: 700;
   letter-spacing: 0.1em; text-transform: uppercase;
   color: var(--c-text-muted);
   margin-bottom: 16px;


### PR DESCRIPTION
## Summary
- `--c-text-muted`を`#a0a0b8`→`#b0b0c8`に明るく調整し、暗背景上のテキストコントラストを改善
- 本文テキストを`0.95rem`→`1rem`に底上げ（pain/solution/enterprise/FAQ各セクション）
- バッジ・タグ類を`0.75rem`→`0.8rem`、注釈を`0.82rem`→`0.875rem`に引き上げ
- デザインバランス・レイアウトは一切変更なし

## Test plan
- [ ] デスクトップ表示で各セクションのテキストが読みやすくなっていること
- [ ] mutedテキスト（説明文・注釈）のコントラストが改善されていること
- [ ] レイアウト・カードサイズに影響がないこと
- [ ] モバイル表示でも読みやすさが維持されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)