### PR TITLE
fix: 保守カードのタグがバブル状に膨らむ問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -775,6 +775,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
 }
 .enterprise-tags {
   display: flex; gap: 8px; flex-wrap: wrap;
+  align-content: start;
 }
 .enterprise-tags span {
   padding: 6px 14px;
@@ -783,6 +784,7 @@ button { cursor: pointer; border: none; font-family: inherit; }
   border-radius: 100px;
   font-size: 0.875rem; font-weight: 500;
   color: var(--c-text-muted);
+  height: fit-content;
 }
 .enterprise-pricing {
   margin-bottom: 24px;


### PR DESCRIPTION
## Summary
- subgridで`enterprise-tags`が縦に引き伸ばされ、短テキストのspanが丸いバブル状に見えていた問題を修正
- `align-content: start`と`height: fit-content`で左右カードのタグ形状を統一

## Test plan
- [ ] 受託開発カードのタグ（要件定義〜デプロイ等）がpill形状であること
- [ ] 保守・運用カードのタグ（障害対応等）が同じpill形状になっていること
- [ ] モバイル表示でもタグが正常表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)