### PR TITLE
feat: 申込みフォームCTAボタンを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -1393,9 +1393,12 @@ AI: 承知しました。
         あなたの課題に合った最適なプランをご提案します。
       </p>
       <div class="final-cta-actions">
-        <a href="https://4173jg.share-na2.hsforms.com/2pgu1PephQXysLrqHDoiPiw" class="btn-primary" target="_blank" rel="noopener noreferrer">
-          無料相談を予約する
+        <a href="https://4173jg.share-na2.hsforms.com/2ZG2T7IpdTvy9xQ9DE5gdeg" class="btn-primary" target="_blank" rel="noopener noreferrer">
+          今すぐ申し込む
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </a>
+        <a href="https://4173jg.share-na2.hsforms.com/2pgu1PephQXysLrqHDoiPiw" class="btn-secondary" target="_blank" rel="noopener noreferrer">
+          まずは無料相談
         </a>
       </div>
     </div>
@@ -1442,7 +1445,7 @@ AI: 承知しました。
 
 <!-- ========== Fixed CTA (Mobile) ========== -->
 <div class="fixed-cta" id="fixedCta">
-  <a href="https://4173jg.share-na2.hsforms.com/2pgu1PephQXysLrqHDoiPiw" class="btn-primary" target="_blank" rel="noopener noreferrer">無料相談を予約する</a>
+  <a href="https://4173jg.share-na2.hsforms.com/2ZG2T7IpdTvy9xQ9DE5gdeg" class="btn-primary" target="_blank" rel="noopener noreferrer">今すぐ申し込む</a>
 </div>
 
 <!-- ========== JavaScript ========== -->


### PR DESCRIPTION
## Summary
- Final CTAに「今すぐ申し込む」ボタン追加（HubSpot申込みフォームへ）
- モバイル固定CTAを申込みフォームに差し替え
- 既存の無料相談リンクはsecondaryボタンとして併設

## Test plan
- [ ] デスクトップでFinal CTAの2ボタン表示確認
- [ ] モバイル固定CTAの表示・遷移確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)